### PR TITLE
Feature/8bitmime off option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,6 @@
 
 # Optional: This will use allow you to set a custom $message_size_limit value. Default is 10240000.
 #MESSAGE_SIZE_LIMIT=
+
+# Optional: This will configure Postfix to ignore an SMTP EHLO 8BITMIME response.  The value set is irrelevent, it is acted on if the environment variable exists.
+#IGNORE_EHLO_8BITMIME=yes

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ The following env variable(s) are optional.
 
 * `TRANSPORT_DISCARD` This is a comma separated list of email addresses that will be discarded. These addresses will not be relayed.
 
+* `IGNORE_EHLO_8BITMIME` Appends "smtp_discard_ehlo_keywords = 8BITMIME" to /etc/postfix/main.cf, this resolves failure to send to broken/old Microsoft Exchange.  Resolves "554 5.6.1 Body type not supported by Remote Host"
+
 To use this container from anywhere, the 25 port or the one specified by `SMTP_PORT` needs to be exposed to the docker host server:
 
     docker run -d --name postfix -p "25:25"  \

--- a/run.sh
+++ b/run.sh
@@ -133,7 +133,7 @@ if [ ! -z "${TRANSPORT_DISCARD}" ]; then
 fi
 
 if [ ! -z "${IGNORE_EHLO_8BITMIME}" ]; then
-  echo "smtp_discard_ehlo_keywords = 8BITMIME" >> /etc/postfix/main.cf
+  postconf -e "smtp_discard_ehlo_keywords = 8BITMIME"
   # Older broken Microsoft Exchange advertises 8BITMIME in response to EHLO
   # Attempting to deliver will fail with error: 554 5.6.1 Body type not supported by Remote Host
   # Postfix main.cf 'smtp_discard_ehlo_keywords = 8BITMIME' instructs postfix to ignore the 8BITMIME

--- a/run.sh
+++ b/run.sh
@@ -132,6 +132,13 @@ if [ ! -z "${TRANSPORT_DISCARD}" ]; then
   echo "Setting configuration option TRANSPORT_DISCARD with value: ${TRANSPORT_DISCARD}"
 fi
 
+if [ ! -z "${IGNORE_EHLO_8BITMIME}" ]; then
+  echo "smtp_discard_ehlo_keywords = 8BITMIME" >> /etc/postfix/main.cf
+  # Older broken Microsoft Exchange advertises 8BITMIME in response to EHLO
+  # Attempting to deliver will fail with error: 554 5.6.1 Body type not supported by Remote Host
+  # Postfix main.cf 'smtp_discard_ehlo_keywords = 8BITMIME' instructs postfix to ignore the 8BITMIME
+fi
+
 #Start services
 
 # If host mounting /var/spool/postfix, we need to delete old pid file before


### PR DESCRIPTION
## Description of the change
Add optional environment variable that when set configures Postfix to ignore 8BITMIME in an EHLO response.

## Motivation and Context
Older/broken Microsoft Exchange indicates 8BITMIME in its EHLO response.
However, 8BITMIME is not supported and use of it results in this error message:
"554 5.6.1 Body type not supported by Remote Host"

## How Has This Been Tested?
The use case where "554 5.6.1 Body type not supported by Remote Host" was observed,
manually revised the Postfix configuration, then observed successfully delivered email.

## Types of Changes
- [x] New feature (non-breaking change which adds functionality)
- [X] Documentation (adding or updating documentation)

## Checklist:
- [X] My change requires a change to the documentation and I have updated the documentation accordingly.
- [X] My change adds a new configuration variable and I have updated the `run.sh` file accordingly.
